### PR TITLE
docs(plugin.xml): fix typo in plugin.xml

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
       <h4>Like the plugin? Star the <a href="https://github.com/loveinsky100/goanno/">Project</a></h4>
       <h4>Got an issue? Report to <a href="https://github.com/loveinsky100/goanno/issues">Issue Tracker</a></h4>
       <h4>How to use?</h4>
-      <h4>1.(control + commend + /) on golang function code</h4>
+      <h4>1.(control + command + /) on golang function code</h4>
       <h4>2.Right click -> Generate -> Goanno</h4>
       <h4>Feature</h4>
       <h4>1.Normal function</h4>
@@ -22,7 +22,7 @@
       <h4>喜欢本插件，点个星星吧！ <a href="https://github.com/loveinsky100/goanno/">github地址</a></h4>
       <h4>有bug？<a href="https://github.com/loveinsky100/goanno/issues">点击此处提交</a></h4>
       <h4>如何使用</h4>
-      <h4>1.在函数上方点击快捷键(control + commend + /)</h4>
+      <h4>1.在函数上方点击快捷键(control + command + /)</h4>
       <h4>2.右键 -> Generate -> Goanno</h4>
 
       <h4>功能</h4>


### PR DESCRIPTION
Same as the previous PR.

FIx the typo in the MacOS Clion plugin introduction page